### PR TITLE
Only add cookie-session if req.session doesn't already exist

### DIFF
--- a/flexdash-dashboard.js
+++ b/flexdash-dashboard.js
@@ -275,7 +275,14 @@ module.exports = function (RED) {
           sameSite: "strict", // strict needed for HTTP to work
         })
         // insert cookie middleware in express, extend validity periodically
-        app.use(this.cookieSession)
+        app.use((req, res, next) => {
+          // Only add a session object if one doesn't already exist
+          if (!req.session) {
+            this.cookieSession(req, res, next)
+          } else {
+            next()
+          }
+        })
         app.use((req, res, next) => {
           //console.log("HTTP:", req.session)
           req.session.now = Math.floor(Date.now() / 3600e3) // extend validity


### PR DESCRIPTION
Fixes #12

One piece I'm not sure on is the socket.io handling - I can see you use some tricks to add headers to the websocket request. In my local testing I *think* that was okay to leave as-is, but would appreciate your input as you've clearly been down that path before.